### PR TITLE
Wake a silent battery during setup, not just during polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,10 +222,11 @@ few failed polls; this is the manual trigger.
 
 **Battery returns no data at all.** After a full power-off some batteries stay
 silent on the 115200 console until they get a wake frame at **1200 baud**
-(`~20014682C0048520FCC3\r`). The integration handles this itself — after a few
-failed polls it drops the console to 1200 baud via `serial_proxy`, sends the
-frame, and switches back. You can also trigger it manually with the
-**`pylontech.wake`** service. The classic USB-serial-adapter-at-1200-baud
+(`~20014682C0048520FCC3\r`). The integration handles this itself — it sends the
+frame at first setup if the console is silent, and again after a few failed
+polls: it drops the console to 1200 baud via `serial_proxy`, sends the frame,
+switches back, and re-enters debug mode. You can also trigger it manually with
+the **`pylontech.wake`** service. The classic USB-serial-adapter-at-1200-baud
 method still works too.
 
 **`pwrsys` / `pwr` return nothing.** They need debug mode — the integration

--- a/custom_components/pylontech/bridge.py
+++ b/custom_components/pylontech/bridge.py
@@ -165,19 +165,27 @@ class PylontechBridge:
 
     async def async_wake(self) -> None:
         """Nudge a silent battery: drop the console to 1200 baud, send the
-        wake frame, switch back to 115200. Needs serial_proxy runtime reconfig
-        (ESPHome >= 2026.3)."""
+        wake frame, switch back to 115200, then re-enter debug mode. Needs
+        serial_proxy runtime reconfig (ESPHome >= 2026.3)."""
         if self._instance is None:
             raise PylontechConnectionError("bridge not connected")
         async with self._lock:
             LOGGER.info("%s: sending 1200-baud wake frame", self._host)
             self._client.serial_proxy_configure(self._instance, WAKE_BAUD)
-            await asyncio.sleep(0.3)
+            await asyncio.sleep(0.5)
             self._client.serial_proxy_write(self._instance, protocol.WAKE_FRAME)
-            await asyncio.sleep(0.6)
+            await asyncio.sleep(1.0)  # let the 22-byte frame clock out at 1200 baud
             self._client.serial_proxy_configure(self._instance, CONSOLE_BAUD)
-            await asyncio.sleep(0.3)
+            await asyncio.sleep(0.5)
             self._buf.clear()
+            # A battery that had powered off comes back in its default,
+            # non-debug mode; prod it with a CR and log back in so that the
+            # next pwrsys/pwr poll returns data.
+            try:
+                await self._raw_command("", timeout=1.5)
+                await self._raw_command(LOGIN_COMMAND, timeout=4.0)
+            except Exception as err:  # noqa: BLE001 - best effort
+                LOGGER.debug("%s: post-wake login failed: %s", self._host, err)
 
     async def _raw_command(self, command: str, timeout: float) -> str:
         assert self._instance is not None

--- a/custom_components/pylontech/coordinator.py
+++ b/custom_components/pylontech/coordinator.py
@@ -66,6 +66,22 @@ class PylontechDataUpdateCoordinator(DataUpdateCoordinator[PylontechData]):
         except PylontechConnectionError as err:
             raise ConfigEntryNotReady(str(err)) from err
 
+        # A battery that was fully powered off stays silent on the 115200
+        # console until it gets a 1200-baud wake frame. A failed setup rebuilds
+        # the coordinator, so the empty-poll wake in _async_update_data never
+        # counts up to its threshold during setup retries — probe once here and
+        # wake straight away if the console is silent.
+        try:
+            probe = await self.bridge.async_command("pwr", timeout=COMMAND_TIMEOUT)
+        except PylontechConnectionError:
+            probe = ""
+        if not protocol.parse_pwr(probe):
+            LOGGER.debug("battery silent at setup, sending 1200-baud wake frame")
+            try:
+                await self.bridge.async_wake()
+            except PylontechConnectionError as err:
+                LOGGER.debug("setup wake failed: %s", err)
+
         try:
             self.info = protocol.parse_info(
                 await self.bridge.async_command("info", timeout=COMMAND_TIMEOUT)

--- a/custom_components/pylontech/manifest.json
+++ b/custom_components/pylontech/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/guybw/PylontechToESPHome/issues",
   "requirements": ["aioesphomeapi>=41.0.0"],
-  "version": "0.1.0"
+  "version": "0.1.1"
 }


### PR DESCRIPTION
A battery that was fully powered off stays silent on the 115200 console until it gets a 1200-baud wake frame. The wake in _async_update_data is gated on an empty-poll counter that lives on the coordinator, but a failed setup rebuilds the coordinator on every retry, so the counter never reaches its threshold and the wake never fired during "Failed setup, will retry: no data parsed from pwrsys/pwr".

- coordinator._async_setup: probe `pwr` once and, if the console is silent, send the wake frame straight away. Runs on every setup retry, so a cold battery gets nudged until it answers.
- bridge.async_wake: after switching back to 115200, prod with a CR and re-send `login debug` — a battery that had powered off comes back in its default, non-debug mode, which pwrsys/pwr need. Also loosen the 1200-baud timing (0.3/0.6/0.3 -> 0.5/1.0/0.5) so the 22-byte frame fully clocks out, matching the reference implementation in simonpasley/pylontech-battery-health.
- manifest: 0.1.0 -> 0.1.1.

Claude-Session: https://claude.ai/code/session_019gifHdqBtYyayXWhKZv2Y2